### PR TITLE
Use CLI strip types flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
       - name: Cache Playwright browsers
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache Playwright browsers
         uses: actions/cache@v3
         with:
-          path: ${{ env.HOME }}/.cache/ms-playwright
+          path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 test-results/
+game.js

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This simple web page lets you play the childhood globe spin game using [CesiumJS](https://cesium.com/platform/cesiumjs/). Click **Spin** to rotate the globe for a few seconds. A semi-transparent circle – the "finger" – follows your mouse at all times. When the spin stops, the game reports the latitude and longitude beneath your finger and looks up the nearest city (or ocean) using the free Nominatim service from OpenStreetMap.
 
-The game logic is written in TypeScript and compiled to JavaScript using Node.js' `--experimental-strip-types` flag. Running the build requires Node 20 or later.
+The game logic is written in TypeScript and compiled to JavaScript using Node.js' `--experimental-strip-types` flag. Running the build requires Node 24 or later.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This simple web page lets you play the childhood globe spin game using [CesiumJS](https://cesium.com/platform/cesiumjs/). Click **Spin** to rotate the globe for a few seconds. A semi-transparent circle – the "finger" – follows your mouse at all times. When the spin stops, the game reports the latitude and longitude beneath your finger and looks up the nearest city (or ocean) using the free Nominatim service from OpenStreetMap.
 
+The game logic is written in TypeScript and compiled to JavaScript using Node.js' `--experimental-strip-types` flag. Running the build requires Node 20 or later.
+
+## Development
+
+Install dependencies and run the tests, which automatically download the required Playwright browsers:
+
+```bash
+npm install
+npm test
+```
+
+The `npm test` command runs the build, installs browsers if necessary and then executes the test suite.
+
 ## Running
 
 Because Cesium uses Web Workers, the page must be served over HTTP. From this

--- a/build.ts
+++ b/build.ts
@@ -1,0 +1,13 @@
+const { readFile, writeFile } = require('fs/promises');
+const { stripTypeScriptTypes } = require('module');
+
+async function build(input: string, output: string): Promise<void> {
+  const code = await readFile(input, 'utf8');
+  const stripped = stripTypeScriptTypes(code);
+  await writeFile(output, stripped);
+  console.log(`Built ${output}`);
+}
+
+(async () => {
+  await build('game.ts', 'game.js');
+})();

--- a/game.ts
+++ b/game.ts
@@ -24,7 +24,12 @@ const infoOverlay = document.getElementById('infoOverlay');
 // show the finger overlay immediately
 fingerEl.style.display = 'block';
 
-async function fetchPlaceInfo(lat, lon) {
+interface PlaceInfo {
+    place: string;
+    waterName: string | null;
+}
+
+async function fetchPlaceInfo(lat: number, lon: number): Promise<PlaceInfo> {
     const url = `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lon}&email=demo@example.com`;
     try {
         const response = await fetch(url);
@@ -47,14 +52,14 @@ async function fetchPlaceInfo(lat, lon) {
     }
 }
 
-async function fetchWikiSummary(title) {
+async function fetchWikiSummary(title: string): Promise<any> {
     const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
     const response = await fetch(url);
     if (!response.ok) throw new Error('No wiki page');
     return await response.json();
 }
 
-async function fetchOfficialWebsite(wikibaseId) {
+async function fetchOfficialWebsite(wikibaseId: string | null): Promise<string | null> {
     if (!wikibaseId) return null;
     const url = `https://www.wikidata.org/wiki/Special:EntityData/${wikibaseId}.json`;
     const response = await fetch(url);
@@ -65,7 +70,7 @@ async function fetchOfficialWebsite(wikibaseId) {
     return claim && claim.mainsnak && claim.mainsnak.datavalue ? claim.mainsnak.datavalue.value : null;
 }
 
-async function fetchImage(title) {
+async function fetchImage(title: string): Promise<any | null> {
     const url = `https://api.openverse.org/v1/images/?q=${encodeURIComponent(title)}&page_size=1`;
     const response = await fetch(url);
     if (!response.ok) return null;
@@ -76,7 +81,7 @@ async function fetchImage(title) {
     return null;
 }
 
-async function fetchWaterBody(lat, lon) {
+async function fetchWaterBody(lat: number, lon: number): Promise<string | null> {
     const url = `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lon}&localityLanguage=en`;
     const response = await fetch(url);
     if (!response.ok) throw new Error('Failed water lookup');
@@ -96,7 +101,7 @@ async function fetchWaterBody(lat, lon) {
 let fingerX = 0;
 let fingerY = 0;
 
-container.addEventListener('mousemove', (e) => {
+container.addEventListener('mousemove', (e: MouseEvent) => {
     fingerX = e.clientX;
     fingerY = e.clientY;
     fingerEl.style.left = fingerX + 'px';
@@ -104,7 +109,7 @@ container.addEventListener('mousemove', (e) => {
 });
 
 
-function spinGlobe() {
+function spinGlobe(): void {
     spinButton.disabled = true;
     resultEl.textContent = 'Spinning...';
     const start = Date.now();

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "This simple web page lets you play the childhood globe spin game using [CesiumJS](https://cesium.com/platform/cesiumjs/). Click **Spin** to rotate the globe for a few seconds. A semi-transparent circle – the \"finger\" – follows your mouse at all times. When the spin stops, the game reports the latitude and longitude beneath your finger and looks up the nearest city (or ocean) using the free Nominatim service from OpenStreetMap.",
   "main": "game.js",
   "scripts": {
-    "start": "npx serve .",
-    "test": "playwright test"
+    "build": "node --experimental-strip-types build.ts",
+    "start": "npm run build && npx serve .",
+    "test": "npm run build && npx playwright install --with-deps && playwright test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- rename `build.mjs` to `build.ts`
- run the build script using Node's `--experimental-strip-types` flag
- update README to mention the new flag
- bump Node version in CI and keep Playwright cache path stable
- add automatic Playwright browser install step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68477e2b8d2483279a2ac3ba0836a194